### PR TITLE
Update proofing method from Groth16 to Plonk

### DIFF
--- a/fault-proof/src/proposer.rs
+++ b/fault-proof/src/proposer.rs
@@ -268,14 +268,14 @@ where
             SP1ProofWithPublicValues::create_mock_proof(
                 &self.prover.agg_pk,
                 public_values,
-                SP1ProofMode::Groth16,
+                SP1ProofMode::Plonk,
                 SP1_CIRCUIT_VERSION,
             )
         } else {
             self.prover
                 .network_prover
                 .prove(&self.prover.agg_pk, &agg_stdin)
-                .groth16()
+                .plonk()
                 .strategy(FulfillmentStrategy::Hosted)
                 .timeout(Duration::from_secs(self.config.timeout))
                 .run_async()

--- a/scripts/prove/bin/agg.rs
+++ b/scripts/prove/bin/agg.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
     println!("Aggregate ELF Verification Key: {:?}", agg_vk.vk.bytes32());
 
     if args.prove {
-        prover.prove(&agg_pk, &stdin).groth16().run().expect("proving failed");
+        prover.prove(&agg_pk, &stdin).plonk().run().expect("proving failed");
     } else {
         let (_, report) = prover.execute(AGGREGATION_ELF, &stdin).run().unwrap();
         println!("report: {report:?}");

--- a/scripts/utils/bin/fetch_rollup_config.rs
+++ b/scripts/utils/bin/fetch_rollup_config.rs
@@ -81,10 +81,10 @@ async fn update_l2oo_config() -> Result<()> {
     let workspace_root = cargo_metadata::MetadataCommand::new().exec()?.workspace_root;
 
     // Set the verifier address
+    // Default to PLONK VerifierGateway contract address
+    // Source: https://docs.succinct.xyz/docs/sp1/verification/contract-addresses
     let verifier = env::var("VERIFIER_ADDRESS").unwrap_or_else(|_| {
-        // Default to Groth16 VerifierGateway contract address
-        // Source: https://docs.succinct.xyz/docs/sp1/verification/contract-addresses
-        "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B".to_string()
+        "0xa236e6e31d94b613923d18313f534ce5b6b98ee1".to_string()
     });
 
     let starting_block_number = match env::var("STARTING_BLOCK_NUMBER") {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes the cryptographic proof system used for aggregation proofs and updates the expected on-chain verifier gateway address, which can break proof verification or deployments if mismatched.
> 
> **Overview**
> Updates aggregation proving to use **Plonk** instead of **Groth16** across the proposer and CLI tooling: mock aggregation proofs are created with `SP1ProofMode::Plonk`, and real aggregation proofs now call `.plonk()`.
> 
> Also changes the rollup config fetch script to default `VERIFIER_ADDRESS` to the Plonk `VerifierGateway` contract address (instead of the Groth16 one), aligning deployments with the new proof type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254fc1e6e8ea6e28606ce5b718a44f0420bdcc48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->